### PR TITLE
Added an error page

### DIFF
--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -1,11 +1,13 @@
 /*jslint browser : true*/
 define([
 	'backbone',
+	'underscore',
 	'utils/logger',
 	'collections/ModelCollection',
+	'views/ErrorView',
 	'views/HomeView',
 	'views/ModelDisplayView'
-], function (Backbone, log, ModelCollection, HomeView, ModelDisplayView) {
+], function (Backbone, _, log, ModelCollection, ErrorView, HomeView, ModelDisplayView) {
 	"use strict";
 	var applicationRouter = Backbone.Router.extend({
 		routes: {
@@ -16,13 +18,28 @@ define([
 		applicationContextDiv : '#page-content-container',
 
 		initialize: function () {
+			var self = this;
 			log.trace("Initializing router");
 
 			// This collection of Sparrow models  will feed into multiple
 			// views so create it here at the top level and pass it into multiple
 			// views in order so that they can decorate their controls
 			this.modelCollection = new ModelCollection();
-			this.modelCollection.fetch();
+			this.modelCollection.fetch().done(function() {
+				if (self.modelCollection.length === 0) {
+					log.error('No metadata in sciencebase response');
+					self.errorView();
+				}
+			})
+			.fail(function(jqXHR, textStatus) {
+				log.error('Error fetching meta data from sciencebase with error ' + textStatus);
+				self.errorView();
+			});
+		},
+
+		errorView : function() {
+			log.trace("Routing to error");
+			this.showView(ErrorView);
 		},
 
 		homeView : function() {

--- a/src/main/webapp/js/templates/app_broken_page.html
+++ b/src/main/webapp/js/templates/app_broken_page.html
@@ -1,0 +1,3 @@
+<div>
+<h1>Unable to retrieve application metadata. Please try again later.</h1>
+</div>

--- a/src/main/webapp/js/views/ErrorView.js
+++ b/src/main/webapp/js/views/ErrorView.js
@@ -1,0 +1,15 @@
+/*jslint browser:true */
+
+define([
+	'views/BaseView',
+	'text!templates/app_broken_page.html'
+], function(BaseView, templateText) {
+	var view = BaseView.extend({
+		template : function() {
+			return templateText;
+		}
+	});
+
+	return view;
+});
+


### PR DESCRIPTION
If the sciencebase call fails or if it returns no data, the page will be replace with an error page. This is in its own template so can be easily changed and styled.

Added tests in AppRouterSpec to test this. Also tested by artificially causing sciencebase errors.