### PR TITLE
Fix fetch prediction

### DIFF
--- a/src/main/webapp/js/models/PredictionModel.js
+++ b/src/main/webapp/js/models/PredictionModel.js
@@ -1,0 +1,38 @@
+/* jslint browser: true */
+/* global define */
+
+define([
+	'utils/logger',
+	'backbone'
+], function(log, Backbone) {
+	"use strict";
+
+	var model = Backbone.Model.extend({
+		defaults : function() {
+			return {
+				catchmentLayerName : '',
+				catchmentStyleName : '',
+				flowlineLayerName : '',
+				flowlineStyleName : '',
+				geoserverEndpoint : ''
+			};
+		},
+
+		urlRoot : 'data/prediction',
+
+		parse : function(response) {
+			return {
+				catchmentLayerName : response[0].CatchLayerName,
+				catchmentStyleName : response[0].CatchLayerDefaultStyleName,
+				flowlineLayerName : response[0].FlowLayerName,
+				flowlineStyleName : response[0].FlowLayerDefaultStyleName,
+				geoserverEndpoint : response[0].EndpointUrl
+			};
+		}
+	});
+
+	return model;
+
+});
+
+

--- a/src/main/webapp/js/views/ModelMapView.js
+++ b/src/main/webapp/js/views/ModelMapView.js
@@ -116,7 +116,7 @@ define([
 		 */
 		updatePredictionModel : function() {
 			//NOTE: Don't put #map-loading-div jquery element in a variable. The view may not be
-			// rendered when this is called but may be when we the fetch is complete
+			// rendered when this is called but may be when the fetch is complete
 			var self = this;
 
 			$('#map-loading-div').show();


### PR DESCRIPTION
Created a new PredictionModel which handles the data/prediction fetching. This info is only fetched when the data series changes and at initialization. The updateModelLayer function is called if the state, watershed, or waterbody filters are changed and after the data/prediction values have been successfully fetched. 